### PR TITLE
lastWeatherLocation

### DIFF
--- a/app/src/main/java/com/resocoder/forecastmvvm/data/repository/ForecastRepositoryImpl.kt
+++ b/app/src/main/java/com/resocoder/forecastmvvm/data/repository/ForecastRepositoryImpl.kt
@@ -22,9 +22,12 @@ class ForecastRepositoryImpl(
     private val locationProvider: LocationProvider
     ) : ForecastRepository {
 
+    private var lastWeatherLocation: WeatherLocation? = null
+    
     init {
         weatherNetworkDataSource.downloadedCurrentWeather.observeForever { newCurrentWeather ->
             persistFetchedCurrentWeather(newCurrentWeather)
+            lastWeatherLocation = newCurrentWeather.location
         }
     }
 
@@ -50,7 +53,6 @@ class ForecastRepositoryImpl(
     }
 
     private suspend fun initWeatherData() {
-        val lastWeatherLocation = weatherLocationDao.getLocation().value
 
         if (lastWeatherLocation == null
             || locationProvider.hasLocationChanged(lastWeatherLocation)) {


### PR DESCRIPTION
Queries that return LiveData, are working asynchronously, so weahterDao.getLocation().value statement in the repository is always returning null. That's why isFetchCurrentNeeded is never triggered.﻿ In order to fix this bug, declare lastWeatherLocation as a nullable property of ForecastRepositoryImpl and set it when downloadedCurrentWeather has changed.